### PR TITLE
Add IPv6 support in the CLI

### DIFF
--- a/ipmininet/cli.py
+++ b/ipmininet/cli.py
@@ -34,6 +34,22 @@ class IPCLI(CLI):
                 lg.info(n, '|', l)
         lg.info('\n')
 
+    def do_ping4all(self, line):
+        """Ping (IPv4-only) between all hosts."""
+        self.mn.ping4All(line)
+
+    def do_ping4pair(self, _line):
+        """Ping (IPv4-only) between first two hosts, useful for testing."""
+        self.mn.ping4Pair()
+
+    def do_ping6all(self, line):
+        """Ping (IPv4-only) between all hosts."""
+        self.mn.ping6All(line)
+
+    def do_ping6pair(self, _line):
+        """Ping (IPv6-only) between first two hosts, useful for testing."""
+        self.mn.ping6Pair()
+
     def default(self, line):
         """Called on an input line when the command prefix is not recognized.
         Overridden to run shell commands when a node is the first CLI argument.

--- a/ipmininet/utils.py
+++ b/ipmininet/utils.py
@@ -36,6 +36,22 @@ def realIntfList(n):
     return [i for i in n.intfList() if i.name != 'lo']
 
 
+def address_pair(n, use_v4=True, use_v6=True):
+    """Returns a tuple (ip, ip6) with ip/ip6 being one of the IPv4/IPv6
+       addresses of the node n"""
+    v4 = v6 = None
+    for itf in realIntfList(n):
+        if use_v4 and v4 is None:
+            v4 = itf.updateIP()
+        if use_v6 and v6 is None:
+            itf.updateIP6()
+            v6 = next(itf.ip6s(exclude_lls=True), None)
+            v6 = v6.ip.compressed if v6 is not None else v6
+        if (not use_v4 or v4 is not None) and (not use_v6 or v6 is not None):
+            break
+    return v4, v6
+
+
 def is_container(x):
     """Return whether x is a container (=iterable but not a string)"""
     return (isinstance(x, collections.Sequence) and


### PR DESCRIPTION
This includes auto-replacement by IPv6 address and ping-related CLI commands that also check IPv6 connectivity.

But this does not include iperf-related CLI commands.