### PR TITLE
Fix BGP config - remove 'passive' command

### DIFF
--- a/ipmininet/router/config/bgp.py
+++ b/ipmininet/router/config/bgp.py
@@ -139,8 +139,7 @@ class Peer(object):
     def __init__(self, base, node):
         """:param base: The base router that has this peer
         :param node: The actual peer"""
-        self.peer, other, self.peer_is_active_opener = self._find_peer_address(
-            base, node)
+        self.peer, other = self._find_peer_address(base, node)
         self.asn = other.asn
         try:
             self.port = other.config.daemon(BGP).port
@@ -169,9 +168,8 @@ class Peer(object):
             for n in i.broadcast_domain.routers:
                 if n.node.name == peer:
                     ip = n.ip
-                    bigger_id = base.config.routerid > n.node.config.routerid
-                    return (ip, n.node, bigger_id) if ip else (
-                        n.ip6, n.node, bigger_id)
+                    return (ip, n.node) if ip else (
+                        n.ip6, n.node)
                 elif n.node.asn == base.asn or not n.node.asn:
                     to_visit.extend(realIntfList(n.node))
-        return None, None, False
+        return None, None

--- a/ipmininet/router/config/templates/bgpd.mako
+++ b/ipmininet/router/config/templates/bgpd.mako
@@ -20,16 +20,6 @@ router bgp ${node.bgpd.asn}
     % if n.ebgp_multihop:
     neighbor ${n.peer} ebgp-multihop
     % endif
-    % if n.peer_is_active_opener:
-    ! In order to avoid simultaneous openings of the BGP session,
-    ! one of the peers has to actively establish the session
-    ! and the other one has to wait.
-    ! The following line makes this router passive for this BGP peering
-    ! because the peer is active.
-    ! Note that BGP would work without this line
-    ! but additional traffic would be generated (see Section 6.8 RFC4271).
-    neighbor ${n.peer} passive
-    % endif
     <%block name="neighbor"/>
 % endfor
 % for af in node.bgpd.address_families:


### PR DESCRIPTION
The condition to activate this command depend on router ids but they are
not yet set in all routers during the building of the bgpd configuration.
Moreover, removing this command does not hurt bgpd because it can handle
simultaneous opening.