### PR TITLE
Add a method addDaemon() to IPTopo

### DIFF
--- a/ipmininet/examples/bgp_decision_process.py
+++ b/ipmininet/examples/bgp_decision_process.py
@@ -41,22 +41,32 @@ class BGPDecisionProcess(IPTopo):
          +------------+                                   +--------+
         """
         # Add all routers
-        as1r1 = self.addRouter('as1r1', config=(RouterConfig, {
-            'daemons': [(BGP, {'address_families': (
-                               _bgp.AF_INET(networks=('1.2.3.0/24',)),)})]}))
-        as2r1 = self.addRouter('as2r1', config=(RouterConfig, {
-            'daemons': [(BGP, {'routerid': '1.1.1.1'}), OSPF]}))
-        as2r2 = self.addRouter('as2r2', config=(RouterConfig, {
-            'daemons': [(BGP, {'routerid': '1.1.1.2'}), OSPF]}))
-        as2r3 = self.addRouter('as2r3', config=(RouterConfig, {
-            'daemons': [OSPF, BGP]}))
-        x = self.addRouter('x', config=(RouterConfig, {
-            'daemons': [OSPF]}))
-        y = self.addRouter('y', config=(RouterConfig, {
-            'daemons': [OSPF]}))
-        as3r1 = self.addRouter('as3r1', config=(RouterConfig, {
-            'daemons': [(BGP, {'address_families': (
-                               _bgp.AF_INET(networks=('1.2.3.0/24',)),)})]}))
+        as1r1 = self.addRouter('as1r1')
+        as1r1.addDaemon(BGP, address_families=(
+            _bgp.AF_INET(networks=('1.2.3.0/24',)),))
+
+        as2r1 = self.addRouter('as2r1')
+        as2r1.addDaemon(BGP, routerid='1.1.1.1')
+        as2r1.addDaemon(OSPF)
+
+        as2r2 = self.addRouter('as2r2')
+        as2r2.addDaemon(BGP, routerid='1.1.1.2')
+        as2r2.addDaemon(OSPF)
+
+        as2r3 = self.addRouter('as2r3')
+        as2r3.addDaemon(BGP)
+        as2r3.addDaemon(OSPF)
+
+        x = self.addRouter('x')
+        x.addDaemon(OSPF)
+
+        y = self.addRouter('y')
+        y.addDaemon(OSPF)
+
+        as3r1 = self.addRouter('as3r1')
+        as3r1.addDaemon(BGP, address_families=(
+            _bgp.AF_INET(networks=('1.2.3.0/24',)),))
+
         self.addLink(as1r1, as2r1)
         self.addLink(as2r1, x, igp_metric=1)
         self.addLink(x, as2r3, igp_metric=10)
@@ -72,3 +82,6 @@ class BGPDecisionProcess(IPTopo):
         ebgp_session(self, as1r1, as2r1)
         ebgp_session(self, as3r1, as2r2)
         super(BGPDecisionProcess, self).build(*args, **kwargs)
+
+    def addRouter(self, name, **kwargs):
+        return super(BGPDecisionProcess, self).addRouter(name, config=RouterConfig, **kwargs)

--- a/ipmininet/examples/iptables.py
+++ b/ipmininet/examples/iptables.py
@@ -13,21 +13,24 @@ from ipmininet.router.config.iptables import Rule
 class IPTablesTopo(IPTopo):
     """This is a simple 2-hosts topology with custom IPTable rules."""
     def build(self, *args, **kw):
-        config = (RouterConfig, {'daemons': [
-            (IPTables, {'rules': [
-              Rule('-A INPUT -p icmp -j ACCEPT'),
-              Rule('-A INPUT -j DROP')]}),
-            (IP6Tables, {'rules': [
-                Rule('-A INPUT -p icmpv6 -m icmpv6',
-                     '--icmpv6-type neighbour-solicitation -j ACCEPT'),
-                Rule('-A INPUT -p icmpv6 -m icmpv6 --icmpv6-type',
-                     'neighbour-advertisement -j ACCEPT'),
-                Rule('-A INPUT -m conntrack --ctstate RELATED,ESTABLISHED',
-                     '-j ACCEPT'),
-                Rule('-A INPUT -m conntrack --ctstate INVALID -j DROP'),
-                Rule('-A INPUT -p tcp -m tcp --tcp-flags FIN,SYN,RST,ACK SYN',
-                     '-m conntrack --ctstate NEW -j ACCEPT'),
-                Rule('-A INPUT -j DROP')]})]})
-        self.addLink(self.addRouter('r1', config=config),
-                     self.addRouter('r2', config=config))
+        ip_rules = [Rule('-A INPUT -p icmp -j ACCEPT'),
+                    Rule('-A INPUT -j DROP')]
+        ip6_rules = [
+            Rule('-A INPUT -p icmpv6 -m icmpv6',
+                 '--icmpv6-type neighbour-solicitation -j ACCEPT'),
+            Rule('-A INPUT -p icmpv6 -m icmpv6 --icmpv6-type',
+                 'neighbour-advertisement -j ACCEPT'),
+            Rule('-A INPUT -m conntrack --ctstate RELATED,ESTABLISHED',
+                 '-j ACCEPT'),
+            Rule('-A INPUT -m conntrack --ctstate INVALID -j DROP'),
+            Rule('-A INPUT -p tcp -m tcp --tcp-flags FIN,SYN,RST,ACK SYN',
+                 '-m conntrack --ctstate NEW -j ACCEPT'),
+            Rule('-A INPUT -j DROP')]
+        r1 = self.addRouter('r1', config=RouterConfig)
+        r2 = self.addRouter('r2', config=RouterConfig)
+        self.addLink(r1, r2)
+        r1.addDaemon(IPTables, rules=ip_rules)
+        r1.addDaemon(IP6Tables, rules=ip6_rules)
+        r2.addDaemon(IPTables, rules=ip_rules)
+        r2.addDaemon(IP6Tables, rules=ip6_rules)
         super(IPTablesTopo, self).build(*args, **kw)

--- a/ipmininet/examples/router_adv_network.py
+++ b/ipmininet/examples/router_adv_network.py
@@ -19,7 +19,8 @@ class RouterAdvNet(IPTopo):
         server.  Note that the DNS service is not actually started and thus the
         host won't get a DNS reply.
         """
-        r = self.addRouter_v6('r', config=(RouterConfig, {'daemons': [RADVD]}))
+        r = self.addRouter_v6('r')
+        r.addDaemon(RADVD)
         h = self.addHost('h')
         dns = self.addHost('dns')
         self.addLink(r, h, params1={
@@ -33,5 +34,5 @@ class RouterAdvNet(IPTopo):
         super(RouterAdvNet, self).build(*args, **kwargs)
 
     def addRouter_v6(self, name, **kwargs):
-        return self.addRouter(name, use_v4=False, use_v6=True, **kwargs)
+        return self.addRouter(name, config=RouterConfig, use_v4=False, use_v6=True, **kwargs)
 

--- a/ipmininet/examples/simple_bgp_network.py
+++ b/ipmininet/examples/simple_bgp_network.py
@@ -4,17 +4,6 @@ from ipmininet.router.config import RouterConfig, BGP, iBGPFullMesh, AS,\
 import ipmininet.router.config.bgp as _bgp
 
 
-class BGPConfig(RouterConfig):
-    """A simple config with only a BGP daemon"""
-    def __init__(self, node, *args, **kwargs):
-        defaults = {'address_families': (
-            _bgp.AF_INET(redistribute=('connected',)),
-            _bgp.AF_INET6(redistribute=('connected',)))}
-        super(BGPConfig, self).__init__(node,
-                                        daemons=((BGP, defaults),),
-                                        *args, **kwargs)
-
-
 class SimpleBGPTopo(IPTopo):
     """This topology builds a 3-AS network exchanging BGP reachability
     information"""
@@ -54,4 +43,8 @@ class SimpleBGPTopo(IPTopo):
         super(SimpleBGPTopo, self).build(*args, **kwargs)
 
     def bgp(self, name):
-        return self.addRouter(name, config=BGPConfig)
+        r = self.addRouter(name, config=RouterConfig)
+        r.addDaemon(BGP, address_families=(
+            _bgp.AF_INET(redistribute=('connected',)),
+            _bgp.AF_INET6(redistribute=('connected',))))
+        return r

--- a/ipmininet/examples/sshd.py
+++ b/ipmininet/examples/sshd.py
@@ -4,9 +4,10 @@ from ipmininet.router.config import SSHd, RouterConfig
 
 
 class SSHTopo(IPTopo):
-    """This is a simple 2-hosts topology with custom IPTable rules."""
     def build(self, *args, **kw):
-        config = (RouterConfig, {'daemons': [SSHd]})
-        self.addLink(self.addRouter('r1', config=config),
-                     self.addRouter('r2', config=config))
+        r1 = self.addRouter('r1', config=RouterConfig)
+        r2 = self.addRouter('r2', config=RouterConfig)
+        self.addLink(r1, r2)
+        r1.addDaemon(SSHd)
+        r2.addDaemon(SSHd)
         super(SSHTopo, self).build(*args, **kw)

--- a/ipmininet/router/config/base.py
+++ b/ipmininet/router/config/base.py
@@ -323,7 +323,7 @@ class Daemon(object):
 class BasicRouterConfig(RouterConfig):
     """A basic router that will run an OSPF daemon"""
 
-    def __init__(self, node, additional_daemons=(), *args, **kwargs):
+    def __init__(self, node, daemons=(), additional_daemons=(), *args, **kwargs):
         """A simple router made of at least an OSPF daemon
 
         :param additional_daemons: Other daemons that should be used"""
@@ -334,7 +334,7 @@ class BasicRouterConfig(RouterConfig):
         # DEPENDS list for that daemon to run it with default settings
         # We also don't want specific settings beside the defaults, so we don't
         # provide an instance but the class instead
-        d = []
+        d = list(daemons)
         if node.use_v4:
             d.append(OSPF)
         if node.use_v6:


### PR DESCRIPTION
This PR adds a new abstraction to configure a daemon on a router in IPMininet.

The IPTopo class returns a `RouterDescription` object which extends `str`.
This object has a method `addDaemon(DaemonClass, **daemon_params)`.
This abstraction is more intuitive than using `addRouter(router_name, config=(ConfigClass, {"daemons": [(DaemonClass, {**daemon_params}), ...]})`.

The examples were updated to demonstrate the use of the abstraction.

This PR also modifies `BasicRouterConfig` to accept a `daemons` parameter for consistency with `RouterConfig`. This shortens the number of parameters of `addDaemon()` to use.